### PR TITLE
Add missing mount_options parameter in filesystem

### DIFF
--- a/ignition/resource_ignition_filesystem.go
+++ b/ignition/resource_ignition_filesystem.go
@@ -44,6 +44,12 @@ func dataSourceFilesystem() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"mount_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"path": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -112,7 +118,12 @@ func buildFilesystem(d *schema.ResourceData) (string, error) {
 
 	options, hasOptions := d.GetOk("options")
 	if hasOptions {
-		fs.Options = castSliceInterfaceToMountOption(options.([]interface{}))
+		fs.Options = castSliceInterfaceToFilesystemOptions(options.([]interface{}))
+	}
+
+	mountOptions, hasMountOptions := d.GetOk("mount_options")
+	if hasMountOptions {
+		fs.MountOptions = castSliceInterfaceToMountOptions(mountOptions.([]interface{}))
 	}
 
 	b, err := json.Marshal(fs)
@@ -127,7 +138,7 @@ func buildFilesystem(d *schema.ResourceData) (string, error) {
 	return hash(string(b)), handleReport(fs.Validate(vcontext_path.ContextPath{}))
 }
 
-func castSliceInterfaceToMountOption(i []interface{}) []types.FilesystemOption {
+func castSliceInterfaceToFilesystemOptions(i []interface{}) []types.FilesystemOption {
 	var o []types.FilesystemOption
 	for _, value := range i {
 		if value == nil {
@@ -135,6 +146,19 @@ func castSliceInterfaceToMountOption(i []interface{}) []types.FilesystemOption {
 		}
 
 		o = append(o, types.FilesystemOption(value.(string)))
+	}
+
+	return o
+}
+
+func castSliceInterfaceToMountOptions(i []interface{}) []types.MountOption {
+	var o []types.MountOption
+	for _, value := range i {
+		if value == nil {
+			continue
+		}
+
+		o = append(o, types.MountOption(value.(string)))
 	}
 
 	return o

--- a/ignition/resource_ignition_filesystem_test.go
+++ b/ignition/resource_ignition_filesystem_test.go
@@ -20,7 +20,8 @@ func TestIgnitionFilesystem(t *testing.T) {
 			wipe_filesystem = true
 			label = "root"
 			uuid = "qux"
-			options = ["rw"]
+			options = ["-L", "test"]
+			mount_options = ["noexec"]
 		}
 		data "ignition_config" "test" {
 			filesystems = [
@@ -64,8 +65,12 @@ func TestIgnitionFilesystem(t *testing.T) {
 			return fmt.Errorf("wipe_filesystem, found %t", *f.WipeFilesystem)
 		}
 
-		if len(f.Options) != 1 || f.Options[0] != "rw" {
+		if len(f.Options) != 2 || f.Options[0] != "-L" || f.Options[1] != "test" {
 			return fmt.Errorf("options, found %q", f.Options)
+		}
+
+		if len(f.MountOptions) != 1 || f.MountOptions[0] != "noexec" {
+			return fmt.Errorf("mountOptions, found %q", f.MountOptions)
 		}
 
 		return nil

--- a/website/docs/d/filesystem.html.md
+++ b/website/docs/d/filesystem.html.md
@@ -36,6 +36,8 @@ The following arguments are supported:
 
 * `options` - (Optional) Any additional options to be passed to the format-specific mkfs utility.
 
+* `mount_options` - (Optional) Any special options to be passed to the mount command.
+
 * `path` - (Optional) The mount-point of the filesystem while Ignition is running relative to where the root filesystem will be mounted. This is not necessarily the same as where it should be mounted in the real root, but it is encouraged to make it the same.
 
 ## Attributes Reference


### PR DESCRIPTION
Closes #79

There was some mixup between the "mount" option from Ignition v2 and the "options" and "mountOptions" from Ignition v3.1+

This commit fixes the names of the related functions, adds mountOptions support and updates the documentation accordingly.

This is my very first PR on a terraform provider, so there might be some mistakes or oversights. Please do not hesitate to tell me how to improve it :)
