### PR TITLE
Allow using user/group instead of uid/gid for directories, files and links

### DIFF
--- a/ignition/resource_ignition_directory.go
+++ b/ignition/resource_ignition_directory.go
@@ -29,15 +29,29 @@ func dataSourceDirectory() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"user": {
+				ConflictsWith: []string{"uid"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+			},
 			"uid": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+				ConflictsWith: []string{"user"},
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ForceNew:      true,
+			},
+			"group": {
+				ConflictsWith: []string{"gid"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
 			},
 			"gid": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+				ConflictsWith: []string{"group"},
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ForceNew:      true,
 			},
 			"rendered": {
 				Type:     schema.TypeString,
@@ -79,9 +93,19 @@ func buildDirectory(d *schema.ResourceData) (string, error) {
 		dir.Mode = &imode
 	}
 
+	user := d.Get("user").(string)
+	if user != "" {
+		dir.User = types.NodeUser{Name: &user}
+	}
+
 	uid := d.Get("uid").(int)
 	if uid != 0 {
 		dir.User = types.NodeUser{ID: &uid}
+	}
+
+	group := d.Get("group").(string)
+	if group != "" {
+		dir.Group = types.NodeGroup{Name: &group}
 	}
 
 	gid := d.Get("gid").(int)

--- a/ignition/resource_ignition_directory_test.go
+++ b/ignition/resource_ignition_directory_test.go
@@ -22,14 +22,22 @@ func TestIgnitionDirectory(t *testing.T) {
 			overwrite = true
 		}
 
+		data "ignition_directory" "named_foo" {
+			path = "/foo"
+			mode = 420
+			user = "foo"
+			group = "foo"
+		}
+
 		data "ignition_config" "test" {
 			directories = [
 				data.ignition_directory.foo.rendered,
 				data.ignition_directory.bar.rendered,
+				data.ignition_directory.named_foo.rendered,
 			]
 		}
 	`, func(c *types.Config) error {
-		if len(c.Storage.Directories) != 2 {
+		if len(c.Storage.Directories) != 3 {
 			return fmt.Errorf("arrays, found %d", len(c.Storage.Directories))
 		}
 
@@ -63,6 +71,27 @@ func TestIgnitionDirectory(t *testing.T) {
 			return fmt.Errorf("overwrite, found %t", *f.Overwrite)
 		}
 
+		f = c.Storage.Directories[2]
+		if f.Path != "/foo" {
+			return fmt.Errorf("path, found %q", f.Path)
+		}
+
+		if *f.Overwrite != false {
+			return fmt.Errorf("overwrite, found %t", *f.Overwrite)
+		}
+
+		if int(*f.Mode) != 420 {
+			return fmt.Errorf("mode, found %q", *f.Mode)
+		}
+
+		if *f.User.Name != "foo" {
+			return fmt.Errorf("user, found %q", *f.User.Name)
+		}
+
+		if *f.Group.Name != "foo" {
+			return fmt.Errorf("group, found %q", *f.Group.Name)
+		}
+
 		return nil
 	})
 }
@@ -91,4 +120,32 @@ func TestIgnitionDirectoryInvalidPath(t *testing.T) {
 			directories = [data.ignition_directory.foo.rendered]
 		}
 	`, regexp.MustCompile("path not absolute"))
+}
+
+func TestIgnitionDirectoryUIDUserConflict(t *testing.T) {
+	testIgnitionError(t, `
+		data "ignition_directory" "foo" {
+			path = "foo"
+			uid = 1000
+			user = "foo"
+		}
+
+		data "ignition_config" "test" {
+			directories = [data.ignition_directory.foo.rendered]
+		}
+	`, regexp.MustCompile("Conflicting configuration arguments"))
+}
+
+func TestIgnitionDirectoryGIDGroupConflict(t *testing.T) {
+	testIgnitionError(t, `
+		data "ignition_directory" "foo" {
+			path = "foo"
+			gid = 1000
+			group = "foo"
+		}
+
+		data "ignition_config" "test" {
+			directories = [data.ignition_directory.foo.rendered]
+		}
+	`, regexp.MustCompile("Conflicting configuration arguments"))
 }

--- a/ignition/resource_ignition_file.go
+++ b/ignition/resource_ignition_file.go
@@ -72,15 +72,29 @@ func dataSourceFile() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"user": {
+				ConflictsWith: []string{"uid"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+			},
 			"uid": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+				ConflictsWith: []string{"user"},
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ForceNew:      true,
+			},
+			"group": {
+				ConflictsWith: []string{"gid"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
 			},
 			"gid": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+				ConflictsWith: []string{"group"},
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ForceNew:      true,
 			},
 			"rendered": {
 				Type:     schema.TypeString,
@@ -157,9 +171,19 @@ func buildFile(d *schema.ResourceData) (string, error) {
 		file.Mode = &imode
 	}
 
+	user := d.Get("user").(string)
+	if user != "" {
+		file.User = types.NodeUser{Name: &user}
+	}
+
 	uid := d.Get("uid").(int)
 	if uid != 0 {
 		file.User = types.NodeUser{ID: &uid}
+	}
+
+	group := d.Get("group").(string)
+	if group != "" {
+		file.Group = types.NodeGroup{Name: &group}
 	}
 
 	gid := d.Get("gid").(int)

--- a/ignition/resource_ignition_file_test.go
+++ b/ignition/resource_ignition_file_test.go
@@ -59,9 +59,19 @@ func TestIgnitionFile(t *testing.T) {
 
 		data "ignition_file" "sas" {
 			path = "/sas"
-			contents { 
+			contents {
 				source = "data:,example%20file%0A"
 			}
+		}
+
+		data "ignition_file" "named_foo" {
+			path = "/foo"
+			contents {
+				source = "data:text/plain;charset=utf-8;base64,${base64encode("foo")}"
+			}
+			mode = 420
+			user = "foo"
+			group = "foo"
 		}
 
 		data "ignition_config" "test" {
@@ -72,10 +82,11 @@ func TestIgnitionFile(t *testing.T) {
 				data.ignition_file.bar.rendered,
 				data.ignition_file.baz.rendered,
 				data.ignition_file.sas.rendered,
+				data.ignition_file.named_foo.rendered,
 			]
 		}
 	`, func(c *types.Config) error {
-		if len(c.Storage.Files) != 6 {
+		if len(c.Storage.Files) != 7 {
 			return fmt.Errorf("arrays, found %d", len(c.Storage.Files))
 		}
 
@@ -189,6 +200,31 @@ func TestIgnitionFile(t *testing.T) {
 			return fmt.Errorf("contents.source, found %q", *f.Contents.Source)
 		}
 
+		f = c.Storage.Files[6]
+		if f.Path != "/foo" {
+			return fmt.Errorf("path, found %q", f.Path)
+		}
+
+		if *f.Overwrite != false {
+			return fmt.Errorf("overwrite, found %t", *f.Overwrite)
+		}
+
+		if string(*f.Contents.Source) != "data:text/plain;charset=utf-8;base64,Zm9v" {
+			return fmt.Errorf("contents.source, found %q", *f.Contents.Source)
+		}
+
+		if int(*f.Mode) != 420 {
+			return fmt.Errorf("mode, found %q", *f.Mode)
+		}
+
+		if *f.User.Name != "foo" {
+			return fmt.Errorf("user, found %q", *f.User.Name)
+		}
+
+		if *f.Group.Name != "foo" {
+			return fmt.Errorf("group, found %q", *f.Group.Name)
+		}
+
 		return nil
 	})
 }
@@ -223,4 +259,38 @@ func TestIgnitionFileInvalidPath(t *testing.T) {
 			files = [data.ignition_file.foo.rendered]
 		}
 	`, regexp.MustCompile("absolute"))
+}
+
+func TestIgnitionFileUIDUserConflict(t *testing.T) {
+	testIgnitionError(t, `
+		data "ignition_file" "foo" {
+			path = "foo"
+			uid = 1000
+			user = "foo"
+			contents {
+				source = "foo"
+			}
+		}
+
+		data "ignition_config" "test" {
+			files = [data.ignition_file.foo.rendered]
+		}
+	`, regexp.MustCompile("Conflicting configuration arguments"))
+}
+
+func TestIgnitionFileGIDGroupConflict(t *testing.T) {
+	testIgnitionError(t, `
+		data "ignition_file" "foo" {
+			path = "foo"
+			gid = 1000
+			group = "foo"
+			contents {
+				source = "foo"
+			}
+		}
+
+		data "ignition_config" "test" {
+			files = [data.ignition_file.foo.rendered]
+		}
+	`, regexp.MustCompile("Conflicting configuration arguments"))
 }

--- a/ignition/resource_ignition_link.go
+++ b/ignition/resource_ignition_link.go
@@ -35,15 +35,29 @@ func dataSourceLink() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"user": {
+				ConflictsWith: []string{"uid"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+			},
 			"uid": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+				ConflictsWith: []string{"user"},
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ForceNew:      true,
+			},
+			"group": {
+				ConflictsWith: []string{"gid"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
 			},
 			"gid": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+				ConflictsWith: []string{"group"},
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ForceNew:      true,
 			},
 			"rendered": {
 				Type:     schema.TypeString,
@@ -91,9 +105,19 @@ func buildLink(d *schema.ResourceData) (string, error) {
 		link.Hard = &bhard
 	}
 
+	user := d.Get("user").(string)
+	if user != "" {
+		link.User = types.NodeUser{Name: &user}
+	}
+
 	uid := d.Get("uid").(int)
 	if uid != 0 {
 		link.User = types.NodeUser{ID: &uid}
+	}
+
+	group := d.Get("group").(string)
+	if group != "" {
+		link.Group = types.NodeGroup{Name: &group}
 	}
 
 	gid := d.Get("gid").(int)

--- a/ignition/resource_ignition_link_test.go
+++ b/ignition/resource_ignition_link_test.go
@@ -24,14 +24,22 @@ func TestIgnitionLink(t *testing.T) {
 			overwrite = true
 		}
 
+		data "ignition_link" "named_foo" {
+			path = "/foo"
+			target = "/bar"
+			user = "foo"
+			group = "foo"
+		}
+
 		data "ignition_config" "test" {
 			links = [
 				data.ignition_link.foo.rendered,
 				data.ignition_link.baz.rendered,
+				data.ignition_link.named_foo.rendered,
 			]
 		}
 	`, func(c *types.Config) error {
-		if len(c.Storage.Links) != 2 {
+		if len(c.Storage.Links) != 3 {
 			return fmt.Errorf("arrays, found %d", len(c.Storage.Links))
 		}
 
@@ -73,6 +81,23 @@ func TestIgnitionLink(t *testing.T) {
 			return fmt.Errorf("overwrite, found %v", *f.Overwrite)
 		}
 
+		f = c.Storage.Links[2]
+		if f.Path != "/foo" {
+			return fmt.Errorf("path, found %q", f.Path)
+		}
+
+		if *f.Target != "/bar" {
+			return fmt.Errorf("target, found %q", *f.Target)
+		}
+
+		if *f.User.Name != "foo" {
+			return fmt.Errorf("user, found %q", *f.User.Name)
+		}
+
+		if *f.Group.Name != "foo" {
+			return fmt.Errorf("group, found %q", *f.Group.Name)
+		}
+
 		return nil
 	})
 }
@@ -88,4 +113,34 @@ func TestIgnitionLinkInvalidPath(t *testing.T) {
 			links = [data.ignition_link.foo.rendered]
 		}
 	`, regexp.MustCompile("absolute"))
+}
+
+func TestIgnitionLinkUIDUserConflict(t *testing.T) {
+	testIgnitionError(t, `
+		data "ignition_link" "foo" {
+			path = "/foo"
+			target = "/bar"
+			uid = 1000
+			user = "foo"
+		}
+
+		data "ignition_config" "test" {
+			links = [data.ignition_link.foo.rendered]
+		}
+	`, regexp.MustCompile("Conflicting configuration arguments"))
+}
+
+func TestIgnitionLinkGIDGroupConflict(t *testing.T) {
+	testIgnitionError(t, `
+		data "ignition_link" "foo" {
+			path = "/foo"
+			target = "/bar"
+			gid = 1000
+			group = "foo"
+		}
+
+		data "ignition_config" "test" {
+			links = [data.ignition_link.foo.rendered]
+		}
+	`, regexp.MustCompile("Conflicting configuration arguments"))
 }

--- a/website/docs/d/directory.html.md
+++ b/website/docs/d/directory.html.md
@@ -28,9 +28,22 @@ The following arguments are supported:
 
 * `mode` - (Optional) The directory's permission mode. Note that the mode must be properly specified as a decimal value, not octal (i.e. 0755 -> 493).
 
+* `user` - (Optional) The user name of the owner.
+
+  __Note__: `user` and `uid` are mutually exclusive.
+
 * `uid` - (Optional) The user ID of the owner.
 
+  __Note__: `uid` and `user` are mutually exclusive.
+
+* `group` - (Optional) The group name of the owner.
+
+  __Note__: `group` and `gid` are mutually exclusive.
+
 * `gid` - (Optional) The group ID of the owner.
+
+  __Note__: `gid` and `group` are mutually exclusive.
+
 
 ## Attributes Reference
 

--- a/website/docs/d/file.html.md
+++ b/website/docs/d/file.html.md
@@ -50,13 +50,25 @@ The following arguments are supported:
 
 * `source` - (Optional) **Deprecated** Block to retrieve the file content from a remote location. Use contents instead.
 
-	__Note__: `content` and `source` are mutually exclusive.
+  __Note__: `content` and `source` are mutually exclusive.
 
 * `mode` - (Optional) The file's permission mode. Note that the mode must be properly specified as a decimal value, not octal (i.e. 0755 -> 493).
 
+* `user` - (Optional) The user name of the owner.
+
+  __Note__: `user` and `uid` are mutually exclusive.
+
 * `uid` - (Optional) The user ID of the owner.
 
+  __Note__: `uid` and `user` are mutually exclusive.
+
+* `group` - (Optional) The group name of the owner.
+
+  __Note__: `group` and `gid` are mutually exclusive.
+
 * `gid` - (Optional) The group ID of the owner.
+
+  __Note__: `gid` and `group` are mutually exclusive.
 
 The `contents` block supports:
 

--- a/website/docs/d/link.html.md
+++ b/website/docs/d/link.html.md
@@ -31,9 +31,22 @@ The following arguments are supported:
 
 * `hard` - (Optional) A symbolic link is created if this is false, a hard one if this is true.
 
+* `user` - (Optional) The user name of the owner.
+
+  __Note__: `user` and `uid` are mutually exclusive.
+
 * `uid` - (Optional) The user ID of the owner.
 
+  __Note__: `uid` and `user` are mutually exclusive.
+
+* `group` - (Optional) The group name of the owner.
+
+  __Note__: `group` and `gid` are mutually exclusive.
+
 * `gid` - (Optional) The group ID of the owner.
+
+  __Note__: `gid` and `group` are mutually exclusive.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
Ignition spec allows specifying user/group name instead of uid/gid for directories, files and links. This is especially handy when assigning them to an existing user where the uid/gid might not be known.